### PR TITLE
Fixes title not getting appended to the timestamp, adds linux section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,19 @@ $ echo 'export PATH=$PATH:$HOME/zk/bin' >> ~/.bashrc
 $ echo 'export ZK_PATH="$HOME/Zettelkasten"' >> ~/.bashrc
 ```
 
-Install the dependencies with your package manager. MacOS:
+Install the dependencies with your package manager.
 
+MacOS:
 ```bash
 # brew install ripgrep fzf sqlite3 bat
+# gem install sqlite3
+```
+
+Linux:
+
+`build-essential`,`libsqlite3-dev` and `ruby-dev` are needed to install the sqlite3 gem. For example—on Debian/Ubuntu, run:
+```bash
+# apt install ripgrep fzf sqlite3 bat build-essential libsqlite3-dev ruby ruby-dev
 # gem install sqlite3
 ```
 

--- a/bin/zkn
+++ b/bin/zkn
@@ -2,6 +2,6 @@
 if [[ -z $1 ]]; then
   zks
 else
-  local args="$@"
+  args="$@"
   nvim -c ":set autochdir" "$ZK_PATH/$(date +"%Y%m%d%H%M") $args.md"
 fi


### PR DESCRIPTION
* Ran into `zkn` not appending the title to the timestamp (tested on Bash 3 and 4). Cause being `line 6: local: can only be used in a function`.
* Additional dependencies are needed on Linux, so added a section in the readme. Might prove helpful to others trying this out on Linux.