### PR TITLE
escape left bracket in fzf bind argument

### DIFF
--- a/bin/zks
+++ b/bin/zks
@@ -12,7 +12,7 @@ fi
 
 fzf --ansi --height 100% --preview 'zk-fts-search -f {} {q} | bat --language md --style=plain --color always' \
   --bind "ctrl-o:execute-silent@tmux send-keys -t \{left\} Escape :read Space ! Space echo Space && \
-          tmux send-keys -t \{left\} -l '\"'[[{}]]'\"' && \
+          tmux send-keys -t \{left\} -l '\"'\[\[{}]]'\"' && \
           tmux send-keys -t \{left\} Enter@" \
   --bind "enter:execute-silent[ \
     tmux send-keys -t \{left\} Escape :e Space && \


### PR DESCRIPTION
This change fix `zfs` for macOS using zsh as default shell.